### PR TITLE
Cache per-user local image URIs to avoid re-downloading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,8 @@ yarn-error.*
 
 # firebase
 services/firebase.js
-services/ 
+services/config.js
+services/myinfo.js
 FirebaseConfig.ts
 FirebaseConfig.js
 results/

--- a/services/ItemContext.js
+++ b/services/ItemContext.js
@@ -1,0 +1,117 @@
+import { createContext, useCallback, useContext, useReducer, useMemo, useEffect } from "react";
+import { baseURL } from "./config";
+
+
+// Contexts
+const DataContext = createContext();
+const ActionsContext = createContext();
+
+
+const initialState = {
+  items: [],
+  categories: [],
+};
+
+// Reducer
+function reducer(state, action) {
+  switch (action.type) {
+    case "add":
+      return { ...state, items: [action.item, ...state.items] };
+    case "update":
+      return {
+        ...state,
+        items: state.items.map((i) =>
+          i.id === action.item.id ? { ...i, ...action.item } : i
+        ),
+      };
+    case "remove":
+      return {
+        ...state,
+        items: state.items.filter((i) => i.id !== action.id),
+      };
+    case "storeCategories":
+      return {
+        ...state,
+        categories: action.payload,
+      };
+    default:
+      return state;
+  }
+}
+
+
+// Provider-component
+export function ItemsProvider({ children }) {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  // Toiminnot
+  const addItem = useCallback((item) => dispatch({ type: "add", item }), []);
+  const updateItem = useCallback((item) => dispatch({ type: "update", item }), []);
+  const removeItem = useCallback((item) => dispatch({ type: "remove", item }), []);
+
+  const storeCategories = useCallback(
+    (categories) => dispatch({ type: "storeCategories", payload: categories }),
+    []
+  );
+
+
+  // Get categories 
+  useEffect(() => {
+    (async () => {
+      try {
+        console.log("🔄 Loading categories...");
+        const res = await fetch(`${baseURL}/categories/`, {
+          method: "GET",
+          headers: { accept: "application/json" },
+        });
+
+        if (!res.ok) {
+          const txt = await res.text().catch(() => "");
+          throw new Error(`Load failed ${res.status}: ${txt}`);
+        }
+
+        const data = await res.json();
+        const catdata = data.map((cat) => ({
+          label: cat.name,
+          value: String(cat.id),
+          key: `cat-${cat.id}`,
+        }));
+
+        storeCategories(catdata);
+        console.log(`✅ Categories loaded (${catdata.length})`);
+      } catch (error) {
+        console.error("❌ Could not load categories", error);
+      }
+    })();
+  }, [storeCategories]);
+
+  // --------------------------
+  // Context-arvot
+  // --------------------------
+  const data = useMemo(() => state, [state]);
+  const actions = useMemo(
+    () => ({ addItem, updateItem, removeItem, storeCategories }),
+    [addItem, updateItem, removeItem, storeCategories]
+  );
+
+  return (
+    <DataContext.Provider value={data}>
+      <ActionsContext.Provider value={actions}>{children}</ActionsContext.Provider>
+    </DataContext.Provider>
+  );
+}
+
+// --------------------------
+// Hookit
+// --------------------------
+export const useItemsData = () => {
+  const ctx = useContext(DataContext);
+  if (!ctx) throw new Error("useItemsData must be used inside ItemsProvider");
+  return ctx;
+};
+
+export const useItemsActions = () => {
+  const ctx = useContext(ActionsContext);
+  if (!ctx) throw new Error("useItemsActions must be used inside ItemsProvider");
+  return ctx;
+};

--- a/services/TestComponent.js
+++ b/services/TestComponent.js
@@ -1,0 +1,25 @@
+// Jokin komponentti, jossa testaat
+import React, { useEffect } from 'react';
+import { database } from '../services/config'; // Oikea polku firebase.ts-tiedostoon
+import { ref, set } from 'firebase/database';
+
+const RealtimeDbTestComponent = () => {
+  useEffect(() => {
+    const testWrite = async () => {
+      try {
+        await set(ref(database, 'test/hello'), 'world');
+        console.log("Realtime Database testikirjoitus onnistui!");
+      } catch (error) {
+        console.error("Realtime Database testikirjoitus epäonnistui:", error);
+      }
+    };
+
+    testWrite();
+  }, []);
+
+  return null; // Tai jokin yksinkertainen tekstikomponentti
+};
+
+export default function  DbTestComponent() {
+    return <RealtimeDbTestComponent />;
+};

--- a/services/auth.js
+++ b/services/auth.js
@@ -1,0 +1,11 @@
+import { createUserWithEmailAndPassword } from 'firebase/auth';
+import { auth } from './config';
+
+// signup wrapper: returns an object with id property (to match existing callers)
+export async function signup(email, password) {
+  const userCredential = await createUserWithEmailAndPassword(auth, email, password);
+  const user = userCredential.user;
+  return { id: user.uid, raw: user };
+}
+
+export default { signup };

--- a/services/firebaseDataBase.js
+++ b/services/firebaseDataBase.js
@@ -1,0 +1,11 @@
+import { doc, setDoc } from 'firebase/firestore';
+import { db } from './config';
+
+// Save user data under collection 'users' with document id = uid
+export async function saveUserData(uid, data) {
+  if (!uid) throw new Error('Missing uid for saveUserData');
+  const ref = doc(db, 'users', uid);
+  await setDoc(ref, data, { merge: true });
+}
+
+export default { saveUserData };

--- a/services/itemsCache.js
+++ b/services/itemsCache.js
@@ -1,0 +1,75 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+const itemsKey = (userId) => `@items_cache_${userId}`;
+const tsKey = (userId) => `@items_cache_ts_${userId}`;
+const refreshKey = (userId) => `@items_cache_refresh_${userId}`;
+
+export function maxTimestamp(items) {
+  let max = null;
+  for (const item of items || []) {
+    if (!item?.timestamp) continue;
+    if (!max || item.timestamp > max) max = item.timestamp;
+  }
+  return max;
+}
+
+export async function loadItemsCache(userId) {
+  if (!userId) return { items: [], lastSync: null };
+  try {
+    const raw = await AsyncStorage.getItem(itemsKey(userId));
+    const ts = await AsyncStorage.getItem(tsKey(userId));
+    return {
+      items: raw ? JSON.parse(raw) : [],
+      lastSync: ts || null,
+    };
+  } catch (e) {
+    console.log("items cache load error", e);
+    return { items: [], lastSync: null };
+  }
+}
+
+export async function saveItemsCache(userId, items, lastSync) {
+  if (!userId) return;
+  try {
+    await AsyncStorage.setItem(itemsKey(userId), JSON.stringify(items || []));
+    if (lastSync) {
+      await AsyncStorage.setItem(tsKey(userId), lastSync);
+    }
+  } catch (e) {
+    console.log("items cache save error", e);
+  }
+}
+
+export async function clearItemsCache(userId) {
+  if (!userId) return;
+  try {
+    await AsyncStorage.removeItem(itemsKey(userId));
+    await AsyncStorage.removeItem(tsKey(userId));
+  } catch (e) {
+    console.log("items cache clear error", e);
+  }
+}
+
+export async function requestItemsRefresh(userId) {
+  if (!userId) return;
+  try {
+    await AsyncStorage.setItem(refreshKey(userId), "1");
+  } catch (e) {
+    console.log("items refresh request error", e);
+  }
+}
+
+export async function consumeItemsRefresh(userId) {
+  if (!userId) return false;
+  try {
+    const flag = await AsyncStorage.getItem(refreshKey(userId));
+    if (flag) {
+      await AsyncStorage.removeItem(refreshKey(userId));
+      return true;
+    }
+    return false;
+  } catch (e) {
+    console.log("items refresh consume error", e);
+    return false;
+  }
+}

--- a/services/itemsImageCache.js
+++ b/services/itemsImageCache.js
@@ -1,0 +1,23 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+const cacheKey = (userId) => `@items_image_cache_${userId}`;
+
+export async function loadImageCache(userId) {
+  if (!userId) return {};
+  try {
+    const raw = await AsyncStorage.getItem(cacheKey(userId));
+    return raw ? JSON.parse(raw) : {};
+  } catch (e) {
+    console.log("image cache load error", e);
+    return {};
+  }
+}
+
+export async function saveImageCache(userId, cache) {
+  if (!userId) return;
+  try {
+    await AsyncStorage.setItem(cacheKey(userId), JSON.stringify(cache || {}));
+  } catch (e) {
+    console.log("image cache save error", e);
+  }
+}

--- a/services/sqlite.js
+++ b/services/sqlite.js
@@ -1,0 +1,54 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import * as SQLite from 'expo-sqlite';
+
+const SQLiteContext = createContext(null);
+
+export function SQLiteProvider({ children }) {
+  const [dbWrapper, setDbWrapper] = useState(null);
+
+  useEffect(() => {
+    const database = SQLite.openDatabase('bonakota.db');
+
+    const wrapper = {
+      rawDb: database,
+      runAsync(sql, params = []) {
+        return new Promise((resolve, reject) => {
+          database.transaction(
+            (tx) => {
+              tx.executeSql(
+                sql,
+                params,
+                (_, result) => resolve(result),
+                (_, err) => {
+                  reject(err);
+                  return false;
+                }
+              );
+            },
+            (txErr) => reject(txErr)
+          );
+        });
+      },
+      async getAllAsync(sql, params = []) {
+        const res = await wrapper.runAsync(sql, params);
+        const rows = [];
+        for (let i = 0; i < res.rows.length; i++) {
+          rows.push(res.rows.item(i));
+        }
+        return rows;
+      },
+    };
+
+    setDbWrapper(wrapper);
+  }, []);
+
+  return <SQLiteContext.Provider value={dbWrapper}>{children}</SQLiteContext.Provider>;
+}
+
+export function useSQLiteContext() {
+  const ctx = useContext(SQLiteContext);
+  if (!ctx) throw new Error('useSQLiteContext must be used within SQLiteProvider');
+  return ctx;
+}
+
+export default { SQLiteProvider, useSQLiteContext };


### PR DESCRIPTION
Implemented a per‑user, device‑local image cache to stop repeated image downloads across sessions/accounts.

Added [itemsImageCache.js](https://file+.vscode-resource.vscode-cdn.net/Users/timolampinen/.vscode/extensions/openai.chatgpt-0.4.68-darwin-arm64/webview/#) to persist a map of itemId -> localUri in AsyncStorage, keyed by user ID.
Updated [MyItemsScreen.js](https://file+.vscode-resource.vscode-cdn.net/Users/timolampinen/.vscode/extensions/openai.chatgpt-0.4.68-darwin-arm64/webview/#) to load the cached map when items are fetched.
Image loading now prefers the cached localUri first; if the file is missing, it downloads from downloadURL and updates the cache.
Removed the old behavior that wrote local file:// URIs back to Firebase; local paths are now device‑only and never pushed to the backend.
Result: each account maintains its own cache on the device, and images are only downloaded once per item unless the local file is deleted.

added services/ and some of the services there like ItemsCache.js and ItemsImageCache.js